### PR TITLE
CRD numatopo scope change namespaced to cluster

### DIFF
--- a/pkg/apis/nodeinfo/v1alpha1/numatopo_types.go
+++ b/pkg/apis/nodeinfo/v1alpha1/numatopo_types.go
@@ -69,8 +69,9 @@ type NumatopoSpec struct {
 }
 
 // +genclient
+// +genclient:nonNamespaced
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=numatopo
+// +kubebuilder:resource:shortName=numatopo,scope=Cluster
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Numatopology is the Schema for the Numatopologies API

--- a/pkg/client/clientset/versioned/typed/nodeinfo/v1alpha1/fake/fake_nodeinfo_client.go
+++ b/pkg/client/clientset/versioned/typed/nodeinfo/v1alpha1/fake/fake_nodeinfo_client.go
@@ -27,8 +27,8 @@ type FakeNodeinfoV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeNodeinfoV1alpha1) Numatopologies(namespace string) v1alpha1.NumatopologyInterface {
-	return &FakeNumatopologies{c, namespace}
+func (c *FakeNodeinfoV1alpha1) Numatopologies() v1alpha1.NumatopologyInterface {
+	return &FakeNumatopologies{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/client/clientset/versioned/typed/nodeinfo/v1alpha1/fake/fake_numatopology.go
+++ b/pkg/client/clientset/versioned/typed/nodeinfo/v1alpha1/fake/fake_numatopology.go
@@ -32,7 +32,6 @@ import (
 // FakeNumatopologies implements NumatopologyInterface
 type FakeNumatopologies struct {
 	Fake *FakeNodeinfoV1alpha1
-	ns   string
 }
 
 var numatopologiesResource = schema.GroupVersionResource{Group: "nodeinfo.volcano.sh", Version: "v1alpha1", Resource: "numatopologies"}
@@ -42,8 +41,7 @@ var numatopologiesKind = schema.GroupVersionKind{Group: "nodeinfo.volcano.sh", V
 // Get takes name of the numatopology, and returns the corresponding numatopology object, and an error if there is any.
 func (c *FakeNumatopologies) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.Numatopology, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(numatopologiesResource, c.ns, name), &v1alpha1.Numatopology{})
-
+		Invokes(testing.NewRootGetAction(numatopologiesResource, name), &v1alpha1.Numatopology{})
 	if obj == nil {
 		return nil, err
 	}
@@ -53,8 +51,7 @@ func (c *FakeNumatopologies) Get(ctx context.Context, name string, options v1.Ge
 // List takes label and field selectors, and returns the list of Numatopologies that match those selectors.
 func (c *FakeNumatopologies) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.NumatopologyList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(numatopologiesResource, numatopologiesKind, c.ns, opts), &v1alpha1.NumatopologyList{})
-
+		Invokes(testing.NewRootListAction(numatopologiesResource, numatopologiesKind, opts), &v1alpha1.NumatopologyList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -75,15 +72,13 @@ func (c *FakeNumatopologies) List(ctx context.Context, opts v1.ListOptions) (res
 // Watch returns a watch.Interface that watches the requested numatopologies.
 func (c *FakeNumatopologies) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(numatopologiesResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(numatopologiesResource, opts))
 }
 
 // Create takes the representation of a numatopology and creates it.  Returns the server's representation of the numatopology, and an error, if there is any.
 func (c *FakeNumatopologies) Create(ctx context.Context, numatopology *v1alpha1.Numatopology, opts v1.CreateOptions) (result *v1alpha1.Numatopology, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(numatopologiesResource, c.ns, numatopology), &v1alpha1.Numatopology{})
-
+		Invokes(testing.NewRootCreateAction(numatopologiesResource, numatopology), &v1alpha1.Numatopology{})
 	if obj == nil {
 		return nil, err
 	}
@@ -93,8 +88,7 @@ func (c *FakeNumatopologies) Create(ctx context.Context, numatopology *v1alpha1.
 // Update takes the representation of a numatopology and updates it. Returns the server's representation of the numatopology, and an error, if there is any.
 func (c *FakeNumatopologies) Update(ctx context.Context, numatopology *v1alpha1.Numatopology, opts v1.UpdateOptions) (result *v1alpha1.Numatopology, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(numatopologiesResource, c.ns, numatopology), &v1alpha1.Numatopology{})
-
+		Invokes(testing.NewRootUpdateAction(numatopologiesResource, numatopology), &v1alpha1.Numatopology{})
 	if obj == nil {
 		return nil, err
 	}
@@ -104,14 +98,13 @@ func (c *FakeNumatopologies) Update(ctx context.Context, numatopology *v1alpha1.
 // Delete takes name of the numatopology and deletes it. Returns an error if one occurs.
 func (c *FakeNumatopologies) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(numatopologiesResource, c.ns, name), &v1alpha1.Numatopology{})
-
+		Invokes(testing.NewRootDeleteAction(numatopologiesResource, name), &v1alpha1.Numatopology{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeNumatopologies) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(numatopologiesResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(numatopologiesResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.NumatopologyList{})
 	return err
@@ -120,8 +113,7 @@ func (c *FakeNumatopologies) DeleteCollection(ctx context.Context, opts v1.Delet
 // Patch applies the patch and returns the patched numatopology.
 func (c *FakeNumatopologies) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.Numatopology, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(numatopologiesResource, c.ns, name, pt, data, subresources...), &v1alpha1.Numatopology{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(numatopologiesResource, name, pt, data, subresources...), &v1alpha1.Numatopology{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset/versioned/typed/nodeinfo/v1alpha1/nodeinfo_client.go
+++ b/pkg/client/clientset/versioned/typed/nodeinfo/v1alpha1/nodeinfo_client.go
@@ -33,8 +33,8 @@ type NodeinfoV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *NodeinfoV1alpha1Client) Numatopologies(namespace string) NumatopologyInterface {
-	return newNumatopologies(c, namespace)
+func (c *NodeinfoV1alpha1Client) Numatopologies() NumatopologyInterface {
+	return newNumatopologies(c)
 }
 
 // NewForConfig creates a new NodeinfoV1alpha1Client for the given config.

--- a/pkg/client/clientset/versioned/typed/nodeinfo/v1alpha1/numatopology.go
+++ b/pkg/client/clientset/versioned/typed/nodeinfo/v1alpha1/numatopology.go
@@ -32,7 +32,7 @@ import (
 // NumatopologiesGetter has a method to return a NumatopologyInterface.
 // A group's client should implement this interface.
 type NumatopologiesGetter interface {
-	Numatopologies(namespace string) NumatopologyInterface
+	Numatopologies() NumatopologyInterface
 }
 
 // NumatopologyInterface has methods to work with Numatopology resources.
@@ -51,14 +51,12 @@ type NumatopologyInterface interface {
 // numatopologies implements NumatopologyInterface
 type numatopologies struct {
 	client rest.Interface
-	ns     string
 }
 
 // newNumatopologies returns a Numatopologies
-func newNumatopologies(c *NodeinfoV1alpha1Client, namespace string) *numatopologies {
+func newNumatopologies(c *NodeinfoV1alpha1Client) *numatopologies {
 	return &numatopologies{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -66,7 +64,6 @@ func newNumatopologies(c *NodeinfoV1alpha1Client, namespace string) *numatopolog
 func (c *numatopologies) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.Numatopology, err error) {
 	result = &v1alpha1.Numatopology{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("numatopologies").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -83,7 +80,6 @@ func (c *numatopologies) List(ctx context.Context, opts v1.ListOptions) (result 
 	}
 	result = &v1alpha1.NumatopologyList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("numatopologies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -100,7 +96,6 @@ func (c *numatopologies) Watch(ctx context.Context, opts v1.ListOptions) (watch.
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("numatopologies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,7 +106,6 @@ func (c *numatopologies) Watch(ctx context.Context, opts v1.ListOptions) (watch.
 func (c *numatopologies) Create(ctx context.Context, numatopology *v1alpha1.Numatopology, opts v1.CreateOptions) (result *v1alpha1.Numatopology, err error) {
 	result = &v1alpha1.Numatopology{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("numatopologies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(numatopology).
@@ -124,7 +118,6 @@ func (c *numatopologies) Create(ctx context.Context, numatopology *v1alpha1.Numa
 func (c *numatopologies) Update(ctx context.Context, numatopology *v1alpha1.Numatopology, opts v1.UpdateOptions) (result *v1alpha1.Numatopology, err error) {
 	result = &v1alpha1.Numatopology{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("numatopologies").
 		Name(numatopology.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -137,7 +130,6 @@ func (c *numatopologies) Update(ctx context.Context, numatopology *v1alpha1.Numa
 // Delete takes name of the numatopology and deletes it. Returns an error if one occurs.
 func (c *numatopologies) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("numatopologies").
 		Name(name).
 		Body(&opts).
@@ -152,7 +144,6 @@ func (c *numatopologies) DeleteCollection(ctx context.Context, opts v1.DeleteOpt
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("numatopologies").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -165,7 +156,6 @@ func (c *numatopologies) DeleteCollection(ctx context.Context, opts v1.DeleteOpt
 func (c *numatopologies) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.Numatopology, err error) {
 	result = &v1alpha1.Numatopology{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("numatopologies").
 		Name(name).
 		SubResource(subresources...).

--- a/pkg/client/informers/externalversions/nodeinfo/v1alpha1/interface.go
+++ b/pkg/client/informers/externalversions/nodeinfo/v1alpha1/interface.go
@@ -40,5 +40,5 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // Numatopologies returns a NumatopologyInformer.
 func (v *version) Numatopologies() NumatopologyInformer {
-	return &numatopologyInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &numatopologyInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/pkg/client/informers/externalversions/nodeinfo/v1alpha1/numatopology.go
+++ b/pkg/client/informers/externalversions/nodeinfo/v1alpha1/numatopology.go
@@ -41,33 +41,32 @@ type NumatopologyInformer interface {
 type numatopologyInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewNumatopologyInformer constructs a new informer for Numatopology type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewNumatopologyInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredNumatopologyInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewNumatopologyInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredNumatopologyInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredNumatopologyInformer constructs a new informer for Numatopology type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredNumatopologyInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredNumatopologyInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NodeinfoV1alpha1().Numatopologies(namespace).List(context.TODO(), options)
+				return client.NodeinfoV1alpha1().Numatopologies().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NodeinfoV1alpha1().Numatopologies(namespace).Watch(context.TODO(), options)
+				return client.NodeinfoV1alpha1().Numatopologies().Watch(context.TODO(), options)
 			},
 		},
 		&nodeinfov1alpha1.Numatopology{},
@@ -77,7 +76,7 @@ func NewFilteredNumatopologyInformer(client versioned.Interface, namespace strin
 }
 
 func (f *numatopologyInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredNumatopologyInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredNumatopologyInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *numatopologyInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/listers/nodeinfo/v1alpha1/expansion_generated.go
+++ b/pkg/client/listers/nodeinfo/v1alpha1/expansion_generated.go
@@ -20,7 +20,3 @@ package v1alpha1
 // NumatopologyListerExpansion allows custom methods to be added to
 // NumatopologyLister.
 type NumatopologyListerExpansion interface{}
-
-// NumatopologyNamespaceListerExpansion allows custom methods to be added to
-// NumatopologyNamespaceLister.
-type NumatopologyNamespaceListerExpansion interface{}

--- a/pkg/client/listers/nodeinfo/v1alpha1/numatopology.go
+++ b/pkg/client/listers/nodeinfo/v1alpha1/numatopology.go
@@ -30,8 +30,9 @@ type NumatopologyLister interface {
 	// List lists all Numatopologies in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.Numatopology, err error)
-	// Numatopologies returns an object that can list and get Numatopologies.
-	Numatopologies(namespace string) NumatopologyNamespaceLister
+	// Get retrieves the Numatopology from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1alpha1.Numatopology, error)
 	NumatopologyListerExpansion
 }
 
@@ -53,41 +54,9 @@ func (s *numatopologyLister) List(selector labels.Selector) (ret []*v1alpha1.Num
 	return ret, err
 }
 
-// Numatopologies returns an object that can list and get Numatopologies.
-func (s *numatopologyLister) Numatopologies(namespace string) NumatopologyNamespaceLister {
-	return numatopologyNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// NumatopologyNamespaceLister helps list and get Numatopologies.
-// All objects returned here must be treated as read-only.
-type NumatopologyNamespaceLister interface {
-	// List lists all Numatopologies in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1alpha1.Numatopology, err error)
-	// Get retrieves the Numatopology from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1alpha1.Numatopology, error)
-	NumatopologyNamespaceListerExpansion
-}
-
-// numatopologyNamespaceLister implements the NumatopologyNamespaceLister
-// interface.
-type numatopologyNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all Numatopologies in the indexer for a given namespace.
-func (s numatopologyNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.Numatopology, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.Numatopology))
-	})
-	return ret, err
-}
-
-// Get retrieves the Numatopology from the indexer for a given namespace and name.
-func (s numatopologyNamespaceLister) Get(name string) (*v1alpha1.Numatopology, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the Numatopology from the index for a given name.
+func (s *numatopologyLister) Get(name string) (*v1alpha1.Numatopology, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: huone1 <huwanxing@huawei.com>
CRD numatopo define per node's cpu topology info, nothing with namespace, so it is better to be in cluster  , not namespaced.

the generated clientset api can reduce the unnecessary arguments

the change is base on the review comment in another PR  https://github.com/volcano-sh/cpu-topology-exporter/pull/1