### PR TITLE
add annotation key TopologyDecisionAnnotation

### DIFF
--- a/pkg/apis/scheduling/v1beta1/labels.go
+++ b/pkg/apis/scheduling/v1beta1/labels.go
@@ -46,3 +46,6 @@ const JDBMaxUnavailable = "volcano.sh/jdb-max-unavailable"
 
 // NumaPolicyKey is the key of pod nuam-topology policy
 const NumaPolicyKey = "volcano.sh/numa-topology-policy"
+
+// TopologyDecisionAnnotation is the key of topology decision about pod request resource
+const TopologyDecisionAnnotation = "volcano.sh/topology-decision"


### PR DESCRIPTION
Signed-off-by: huone1 <huwanxing@huawei.com>

TopologyDecisionAnnotation is used to provide a way to submit the pod resource assigned topology to kubelet, Maybe the custom kubelet of some Applicators use it to resource allocation