### PR TITLE
Set stopCh's buffer size as 2

### DIFF
--- a/pkg/apis/helpers/helpers.go
+++ b/pkg/apis/helpers/helpers.go
@@ -204,7 +204,7 @@ func runServer(server *http.Server, ln net.Listener) error {
 		return fmt.Errorf("listener and server must not be nil")
 	}
 
-	stopCh := make(chan os.Signal)
+	stopCh := make(chan os.Signal, 2)
 	signal.Notify(stopCh, syscall.SIGTERM, syscall.SIGINT)
 
 	go func() {


### PR DESCRIPTION
Unbuffered os.Signal channel (`stopCh`) cannot be the argument of `signal.Notify()`. Considering that `stopCh` is designed for receiving two signals `syscall.SIGTERM`, and `syscall.SIGINT`, the buffer size should be `2`.
