### PR TITLE
add stable preempt label

### DIFF
--- a/pkg/apis/scheduling/v1beta1/labels.go
+++ b/pkg/apis/scheduling/v1beta1/labels.go
@@ -44,7 +44,7 @@ const PodPreemptable = "volcano.sh/preemptable"
 
 // PodPreemptStableTime is the key of preempt-stable-time, value's format "600s","10m" 
 // Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". 
-const PodPreemptStableTime = "volcano.sh/preempt-stable-time"
+const PreemptStableTime = "volcano.sh/preempt-stable-time"
 
 //RevocableZone is the key of revocable-zone
 const RevocableZone = "volcano.sh/revocable-zone"

--- a/pkg/apis/scheduling/v1beta1/labels.go
+++ b/pkg/apis/scheduling/v1beta1/labels.go
@@ -42,6 +42,9 @@ const QueueNameAnnotationKey = GroupName + "/queue-name"
 // PodPreemptable is the key of preemptable
 const PodPreemptable = "volcano.sh/preemptable"
 
+// PodPreemptStableTime is the key of preempt-stable-time, value's unit is second
+const PodPreemptStableTime = "volcano.sh/preempt-stable-time"
+
 //RevocableZone is the key of revocable-zone
 const RevocableZone = "volcano.sh/revocable-zone"
 

--- a/pkg/apis/scheduling/v1beta1/labels.go
+++ b/pkg/apis/scheduling/v1beta1/labels.go
@@ -42,7 +42,8 @@ const QueueNameAnnotationKey = GroupName + "/queue-name"
 // PodPreemptable is the key of preemptable
 const PodPreemptable = "volcano.sh/preemptable"
 
-// PodPreemptStableTime is the key of preempt-stable-time, value's unit is second
+// PodPreemptStableTime is the key of preempt-stable-time, value's format "600s","10m" 
+// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". 
 const PodPreemptStableTime = "volcano.sh/preempt-stable-time"
 
 //RevocableZone is the key of revocable-zone


### PR DESCRIPTION
related to volcano pr [#2149](https://github.com/volcano-sh/volcano/pull/2149) and  issue [#2075](https://github.com/volcano-sh/volcano/issues/2075)
add a new label "volcano.sh/preempt-stable-time“ to indicate cool down time for preemptees