### PR TITLE
update scripts to use go install

### DIFF
--- a/hack/generate-groups.sh
+++ b/hack/generate-groups.sh
@@ -46,7 +46,7 @@ APIS_PKG="$3"
 GROUPS_WITH_VERSIONS="$4"
 shift 4
 
-go get k8s.io/code-generator/cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}@v0.23.0
+go install k8s.io/code-generator/cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}@v0.23.0
 
 # Go installs the above commands to get installed in $GOBIN if defined, and $GOPATH/bin otherwise:
 GOBIN="$(go env GOBIN)"

--- a/hack/generate-internal-groups.sh
+++ b/hack/generate-internal-groups.sh
@@ -47,7 +47,7 @@ EXT_APIS_PKG="$4"
 GROUPS_WITH_VERSIONS="$5"
 shift 5
 
-go get k8s.io/code-generator/cmd/{defaulter-gen,conversion-gen,client-gen,lister-gen,informer-gen,deepcopy-gen,openapi-gen}@v0.23.0
+go install k8s.io/code-generator/cmd/{defaulter-gen,conversion-gen,client-gen,lister-gen,informer-gen,deepcopy-gen,openapi-gen}@v0.23.0
 
 # Go installs the above commands to get installed in $GOBIN if defined, and $GOPATH/bin otherwise:
 GOBIN="$(go env GOBIN)"


### PR DESCRIPTION
The `go get` command had been deprecated.  When running `go get` it recommends updating to `go install`.  This replaces the occurrences of `go get` with `go install`.

Signed-off-by: Robert Christensen <robert.christensen@gmail.com>