### PR TITLE
add volcano group min resources annotation key

### DIFF
--- a/pkg/apis/scheduling/v1beta1/labels.go
+++ b/pkg/apis/scheduling/v1beta1/labels.go
@@ -35,6 +35,10 @@ const KubeGroupNameAnnotationKey = "scheduling.k8s.io/group-name"
 // which PodGroup it belongs to.
 const VolcanoGroupNameAnnotationKey = GroupName + "/group-name"
 
+// VolcanoGroupMinResourcesAnnotationKey is the annotation key of PodGroup's PodGroup.Spec.MinResources
+// which PodGroup it belongs to.
+const VolcanoGroupMinResourcesAnnotationKey = GroupName + "/group-min-resources"
+
 // QueueNameAnnotationKey is the annotation key of Pod to identify
 // which queue it belongs to.
 const QueueNameAnnotationKey = GroupName + "/queue-name"


### PR DESCRIPTION
For solve this situation

- When we use spark client model to submit spark job in k8s with volcano scheduler. hope all executors can be managed and scheduled through podgroup.

- hope some single pods can be managed and scheduled through podgroup with volcano.


Signed-off-by: Binbin Zou <binbin.zou@BinbinZoudeMacBook-Pro.local>