### PR TITLE
jason add max cooldown times label

### DIFF
--- a/pkg/apis/scheduling/v1beta1/labels.go
+++ b/pkg/apis/scheduling/v1beta1/labels.go
@@ -50,6 +50,10 @@ const PodPreemptable = "volcano.sh/preemptable"
 // Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 const CooldownTime = "volcano.sh/cooldown-time"
 
+// MaxCooldownTimes is the annotation key of Pod to set maximum number of cooldown(evictions),
+//value's format "0", 1. 0 means no limit.
+const MaxCooldownTimes = "volcano.sh/max-cooldown-times"
+
 //RevocableZone is the key of revocable-zone
 const RevocableZone = "volcano.sh/revocable-zone"
 


### PR DESCRIPTION
related to volcano pr [#2363](https://github.com/volcano-sh/volcano/pull/2363)
add a new label "volcano.sh/max-cooldown-times" to indicate cool down time for preempted

Signed-off-by: 刘毅（Jason Liu） <liuyi03@qiyi.com>