### PR TITLE
fix: close stopCh when recv signal

### DIFF
--- a/pkg/apis/helpers/helpers.go
+++ b/pkg/apis/helpers/helpers.go
@@ -226,6 +226,7 @@ func runServer(server *http.Server, ln net.Listener) error {
 
 	go func() {
 		<-stopCh
+		close(stopCh)
 		ctx, cancel := context.WithTimeout(context.Background(), 0)
 		server.Shutdown(ctx)
 		cancel()


### PR DESCRIPTION
### change

if don't close stopCh,  call `klog.Fatalf`.

<img width="814" alt="image" src="https://github.com/volcano-sh/apis/assets/3785409/487db89f-d35b-4bed-a18e-ac81e0e03fe6">

