### PR TITLE
add task index key for pod in annotation/label

### DIFF
--- a/pkg/apis/batch/v1alpha1/labels.go
+++ b/pkg/apis/batch/v1alpha1/labels.go
@@ -19,6 +19,8 @@ package v1alpha1
 const (
 	// TaskSpecKey task spec key used in pod annotation
 	TaskSpecKey = "volcano.sh/task-spec"
+	// TaskIndex is task index of each spec in annotation / labels
+	TaskIndex = "volcano.sh/task-index"
 	// JobNameKey job name key used in pod annotation / labels
 	JobNameKey = "volcano.sh/job-name"
 	// QueueNameKey queue name key used in pod annotation / labels


### PR DESCRIPTION
add a index for each replica of different task spec/role in pod, like kubeflow's tf/pytorch

relative issue at [how to create a service for every task pod #2654](https://github.com/volcano-sh/volcano/issues/2654)

Relative PR at volcano repo: [Add task index #3076](https://github.com/volcano-sh/volcano/pull/3076)
