### PR TITLE
Fix `Parent` field lost in conversion

### DIFF
--- a/pkg/apis/scheduling/v1beta1/conversion.go
+++ b/pkg/apis/scheduling/v1beta1/conversion.go
@@ -28,6 +28,7 @@ func Convert_scheduling_QueueSpec_To_v1beta1_QueueSpec(in *scheduling.QueueSpec,
 	out.Weight = in.Weight
 	out.Capability = *(*v1.ResourceList)(unsafe.Pointer(&in.Capability))
 	out.Reclaimable = (*bool)(unsafe.Pointer(in.Reclaimable))
+	out.Parent = in.Parent
 
 	return nil
 }

--- a/pkg/apis/scheduling/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/scheduling/v1beta1/zz_generated.conversion.go
@@ -523,6 +523,7 @@ func autoConvert_v1beta1_QueueSpec_To_scheduling_QueueSpec(in *QueueSpec, out *s
 	}
 	out.Affinity = (*scheduling.Affinity)(unsafe.Pointer(in.Affinity))
 	out.Type = in.Type
+	out.Parent = in.Parent
 	return nil
 }
 


### PR DESCRIPTION
In [pr118](https://github.com/volcano-sh/apis/pull/118)，api add a new field: parent to support Hierarchical Proportion in future. 
However, while using it, I noticed that the "parent" field is always empty. The reason for this issue is that the API's conversion logic does not take into account the "parent" field, causing the `UpdateQueueStatus` method in volcano `cache.go` to lose the "parent" field when the`schedulingscheme.Scheme.Convert` method is called.