### PR TITLE
Added pod annotation key: JobRetryCountKey = volcano.sh/job-retry-count

### DIFF
--- a/pkg/apis/batch/v1alpha1/labels.go
+++ b/pkg/apis/batch/v1alpha1/labels.go
@@ -33,6 +33,8 @@ const (
 	JobVersion = "volcano.sh/job-version"
 	// JobTypeKey job type key used in labels
 	JobTypeKey = "volcano.sh/job-type"
+	// JobRetryCountKey job retry count key used in pod annotation
+	JobRetryCountKey = "volcano.sh/job-retry-count"
 	// PodgroupNamePrefix podgroup name prefix
 	PodgroupNamePrefix = "podgroup-"
 	// PodTemplateKey type specify a equivalence pod class


### PR DESCRIPTION
Added an annotation key to store the current Job retry count (`Job.Status.RetryCount`) in the pod's annotations.

Feat: https://github.com/volcano-sh/volcano/issues/3528, #127

---

We need to decide on the annotation key - `volcano.sh/retry-count` or `volcano.sh/job-retry-count`?