### PR TITLE
Remove useless RestartPod Action

### DIFF
--- a/pkg/apis/bus/v1alpha1/actions.go
+++ b/pkg/apis/bus/v1alpha1/actions.go
@@ -32,10 +32,6 @@ const (
 	// This action can not work together with job level events, e.g. JobUnschedulable
 	RestartTaskAction Action = "RestartTask"
 
-	// RestartPodAction if this action is set, only the pod will be restarted; default action.
-	// This action can just work together with pod level events, e.g. PodFailed
-	RestartPodAction Action = "RestartPod"
-
 	// TerminateJobAction if this action is set, the whole job wil be terminated
 	// and can not be resumed: all Pod of Job will be evicted, and no Pod will be recreated.
 	TerminateJobAction Action = "TerminateJob"


### PR DESCRIPTION
In the context of Volcano, task and pod are the same type of resource. Therefore, RestartPod and RestartTask are redundant actions, so RestartPod should be removed.