### PR TITLE
Add RestartPod action for pod reschedule

### DIFF
--- a/pkg/apis/bus/v1alpha1/actions.go
+++ b/pkg/apis/bus/v1alpha1/actions.go
@@ -28,9 +28,15 @@ const (
 	// RestartJobAction if this action is set, the whole job will be restarted
 	RestartJobAction Action = "RestartJob"
 
-	// RestartTaskAction if this action is set, only the task will be restarted; default action.
+	// RestartTaskAction if this action is set, only the task will be restarted
+	// It means that all pods under the task will be deleted and recreated.
 	// This action can not work together with job level events, e.g. JobUnschedulable
 	RestartTaskAction Action = "RestartTask"
+
+	// RestartPodAction if this action is set, only the pod will be restarted
+	// It means that only the pod corresponding to the event will be deleted and recreated.
+	// This action can just work together with pod level events, e.g. PodFailed
+	RestartPodAction Action = "RestartPod"
 
 	// TerminateJobAction if this action is set, the whole job wil be terminated
 	// and can not be resumed: all Pod of Job will be evicted, and no Pod will be recreated.


### PR DESCRIPTION
prepare for the volcano issue https://github.com/volcano-sh/volcano/issues/3812

Correct the misunderstanding in this PR #141 
In the context of the Volcano scheduler, **task** and **pod** are the same type of resource.
However, in Volcano controllers, a **task** is a higher-level resource above a **pod**. A single **Volcano job** can contain multiple **tasks**, and each **task** can include multiple **pods**.