### PR TITLE
HyperNode supports select Nodes By labels

### DIFF
--- a/pkg/apis/topology/v1alpha1/hypernode_types.go
+++ b/pkg/apis/topology/v1alpha1/hypernode_types.go
@@ -81,11 +81,11 @@ type MemberSpec struct {
 //
 // Example for Exact match:
 //
-//	members:
-//  - type: Node
-//	  selector:
-//	    exactMatch:
-//	      name: "node1"
+//		members:
+//	 - type: Node
+//		  selector:
+//		    exactMatch:
+//		      name: "node1"
 //
 // Example for Regex match:
 //
@@ -95,16 +95,20 @@ type MemberSpec struct {
 //		   regexMatch:
 //		     pattern: "^node-[0-9]+$"
 //
-// +kubebuilder:validation:XValidation:rule="has(self.exactMatch) || has(self.regexMatch)",message="Either ExactMatch or RegexMatch must be specified"
-// +kubebuilder:validation:XValidation:rule="!(has(self.exactMatch) && has(self.regexMatch))",message="ExactMatch and RegexMatch cannot be specified together"
+// +kubebuilder:validation:XValidation:rule="has(self.exactMatch) || has(self.regexMatch) || has(self.LabelMatch)",message="Either ExactMatch or RegexMatch or LabelMatch must be specified"
+// +kubebuilder:validation:XValidation:rule="!(has(self.exactMatch) && has(self.regexMatch) && has(self.LabelMatch))",message="ExactMatch and RegexMatch and LabelMatch cannot be specified together"
 type MemberSelector struct {
-	// ExactMatch defines the exact match criteria (required when Type is "Exact").
+	// ExactMatch defines the exact match criteria.
 	// +optional
 	ExactMatch *ExactMatch `json:"exactMatch,omitempty"`
 
-	// RegexMatch defines the regex match criteria (required when Type is "Regex").
+	// RegexMatch defines the regex match criteria.
 	// +optional
 	RegexMatch *RegexMatch `json:"regexMatch,omitempty"`
+
+	// LabelMatch defines the labels match criteria (only take effect when Member Type is "Node").
+	// +optional
+	LabelMatch *metav1.LabelSelector `json:"labelMatch,omitempty"`
 }
 
 // ExactMatch represents the criteria for exact name matching.

--- a/pkg/apis/topology/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/topology/v1alpha1/zz_generated.deepcopy.go
@@ -161,6 +161,11 @@ func (in *MemberSelector) DeepCopyInto(out *MemberSelector) {
 		*out = new(RegexMatch)
 		**out = **in
 	}
+	if in.LabelMatch != nil {
+		in, out := &in.LabelMatch, &out.LabelMatch
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/client/applyconfiguration/topology/v1alpha1/memberselector.go
+++ b/pkg/client/applyconfiguration/topology/v1alpha1/memberselector.go
@@ -17,11 +17,16 @@ limitations under the License.
 
 package v1alpha1
 
+import (
+	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
+)
+
 // MemberSelectorApplyConfiguration represents a declarative configuration of the MemberSelector type for use
 // with apply.
 type MemberSelectorApplyConfiguration struct {
-	ExactMatch *ExactMatchApplyConfiguration `json:"exactMatch,omitempty"`
-	RegexMatch *RegexMatchApplyConfiguration `json:"regexMatch,omitempty"`
+	ExactMatch *ExactMatchApplyConfiguration       `json:"exactMatch,omitempty"`
+	RegexMatch *RegexMatchApplyConfiguration       `json:"regexMatch,omitempty"`
+	LabelMatch *v1.LabelSelectorApplyConfiguration `json:"labelMatch,omitempty"`
 }
 
 // MemberSelectorApplyConfiguration constructs a declarative configuration of the MemberSelector type for use with
@@ -43,5 +48,13 @@ func (b *MemberSelectorApplyConfiguration) WithExactMatch(value *ExactMatchApply
 // If called multiple times, the RegexMatch field is set to the value of the last call.
 func (b *MemberSelectorApplyConfiguration) WithRegexMatch(value *RegexMatchApplyConfiguration) *MemberSelectorApplyConfiguration {
 	b.RegexMatch = value
+	return b
+}
+
+// WithLabelMatch sets the LabelMatch field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the LabelMatch field is set to the value of the last call.
+func (b *MemberSelectorApplyConfiguration) WithLabelMatch(value *v1.LabelSelectorApplyConfiguration) *MemberSelectorApplyConfiguration {
+	b.LabelMatch = value
 	return b
 }


### PR DESCRIPTION
What this PR does / why we need it:

HyperNode supports select Nodes By labels.

Which issue(s) this PR fixes:
https://github.com/volcano-sh/volcano/issues/4007