### PR TITLE
Set optional for allocated in queue status

### DIFF
--- a/pkg/apis/scheduling/types.go
+++ b/pkg/apis/scheduling/types.go
@@ -288,6 +288,7 @@ type QueueStatus struct {
 	Reservation Reservation
 
 	// Allocated is allocated resources in queue
+	// +optional
 	Allocated v1.ResourceList
 }
 

--- a/pkg/apis/scheduling/v1beta1/types.go
+++ b/pkg/apis/scheduling/v1beta1/types.go
@@ -305,6 +305,7 @@ type QueueStatus struct {
 	Reservation Reservation `json:"reservation,omitempty" protobuf:"bytes,7,opt,name=reservation"`
 
 	// Allocated is allocated resources in queue
+	// +optional
 	Allocated v1.ResourceList `json:"allocated" protobuf:"bytes,8,opt,name=allocated"`
 }
 


### PR DESCRIPTION
Ref: https://github.com/volcano-sh/volcano/issues/4139

Currently, the vc-controller must specify the allocated field to update the status because allocated is not optional. The scheduler also updates allocated, which may potentially lead to conflicts, causing the queue to not open:
https://github.com/volcano-sh/volcano/blob/1ae9a84e16bb327aa54420863cba3c4588e6e325/pkg/controllers/queue/queue_controller_action.go#L101-L107

Therefore, we need to set optional for allocated, and then remove above codes in vc-controller