### PR TITLE
[cherry-pick v1.11] Set optional for allocated in queue status

### DIFF
--- a/pkg/apis/scheduling/types.go
+++ b/pkg/apis/scheduling/types.go
@@ -288,6 +288,7 @@ type QueueStatus struct {
 	Reservation Reservation
 
 	// Allocated is allocated resources in queue
+	// +optional
 	Allocated v1.ResourceList
 }
 

--- a/pkg/apis/scheduling/v1beta1/types.go
+++ b/pkg/apis/scheduling/v1beta1/types.go
@@ -304,6 +304,7 @@ type QueueStatus struct {
 	Reservation Reservation `json:"reservation,omitempty" protobuf:"bytes,7,opt,name=reservation"`
 
 	// Allocated is allocated resources in queue
+	// +optional
 	Allocated v1.ResourceList `json:"allocated" protobuf:"bytes,8,opt,name=allocated"`
 }
 


### PR DESCRIPTION
Cherry-pick https://github.com/volcano-sh/apis/pull/163 to release-1.11 for releasing a patch version