### PR TITLE
Fix the labelSelector capitalization issue and set memberSelector to …

### DIFF
--- a/pkg/apis/topology/v1alpha1/hypernode_types.go
+++ b/pkg/apis/topology/v1alpha1/hypernode_types.go
@@ -95,8 +95,8 @@ type MemberSpec struct {
 //		   regexMatch:
 //		     pattern: "^node-[0-9]+$"
 //
-// +kubebuilder:validation:XValidation:rule="has(self.exactMatch) || has(self.regexMatch) || has(self.LabelMatch)",message="Either ExactMatch or RegexMatch or LabelMatch must be specified"
-// +kubebuilder:validation:XValidation:rule="!(has(self.exactMatch) && has(self.regexMatch) && has(self.LabelMatch))",message="ExactMatch and RegexMatch and LabelMatch cannot be specified together"
+// +kubebuilder:validation:XValidation:rule="has(self.exactMatch) || has(self.regexMatch) || has(self.labelMatch)",message="Either ExactMatch or RegexMatch or LabelMatch must be specified"
+// +kubebuilder:validation:XValidation:rule="(has(self.exactMatch) ? 1 : 0) + (has(self.regexMatch) ? 1 : 0) + (has(self.labelMatch) ? 1 : 0) <= 1",message="Only one of ExactMatch, RegexMatch, or LabelMatch can be specified"
 type MemberSelector struct {
 	// ExactMatch defines the exact match criteria.
 	// +optional

--- a/pkg/apis/topology/v1alpha1/hypernode_types.go
+++ b/pkg/apis/topology/v1alpha1/hypernode_types.go
@@ -95,6 +95,15 @@ type MemberSpec struct {
 //		   regexMatch:
 //		     pattern: "^node-[0-9]+$"
 //
+// Example for Label match:
+//
+//	members:
+//	- type: Node
+//	  selector:
+//	    labelMatch:
+//	      matchLabels:
+//	        topology-rack: rack1
+//
 // +kubebuilder:validation:XValidation:rule="has(self.exactMatch) || has(self.regexMatch) || has(self.labelMatch)",message="Either ExactMatch or RegexMatch or LabelMatch must be specified"
 // +kubebuilder:validation:XValidation:rule="(has(self.exactMatch) ? 1 : 0) + (has(self.regexMatch) ? 1 : 0) + (has(self.labelMatch) ? 1 : 0) <= 1",message="Only one of ExactMatch, RegexMatch, or LabelMatch can be specified"
 type MemberSelector struct {


### PR DESCRIPTION
Fix #161

1. Use ternary expression method to verify that memerSelector can only select one of three matching types, if more than two matching types are found, creation is rejected
2. Besides, fix the issue of labelMatch being in uppercase, which causes a compilation error

### validation
Create a hypernode that specifies both exactMatch and regexMatch, declined by the api-server:
![image](https://github.com/user-attachments/assets/c113fe7f-ff01-43fe-8bd3-e525686c2b37)
![image](https://github.com/user-attachments/assets/04d000c6-af8f-43e2-a9c9-40135519f742)
