### PR TITLE
feat: add ActiveDeadlineSeconds to JobSpec

### DIFF
--- a/pkg/apis/batch/v1alpha1/job.go
+++ b/pkg/apis/batch/v1alpha1/job.go
@@ -91,6 +91,10 @@ type JobSpec struct {
 	// +optional
 	MaxRetry int32 `json:"maxRetry,omitempty" protobuf:"bytes,9,opt,name=maxRetry"`
 
+	// ActiveDeadlineSeconds specifies the duration in seconds relative to the startTime that the job may be active before it is terminated.
+	// +optional
+	ActiveDeadlineSeconds *int64 `json:"activeDeadlineSeconds,omitempty" protobuf:"varint,14,opt,name=activeDeadlineSeconds"`
+
 	// ttlSecondsAfterFinished limits the lifetime of a Job that has finished
 	// execution (either Completed or Failed). If this field is set,
 	// ttlSecondsAfterFinished after the Job finishes, it is eligible to be

--- a/pkg/apis/batch/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/batch/v1alpha1/zz_generated.deepcopy.go
@@ -173,6 +173,11 @@ func (in *JobSpec) DeepCopyInto(out *JobSpec) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.ActiveDeadlineSeconds != nil {
+		in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
+		*out = new(int64)
+		**out = **in
+	}
 	if in.TTLSecondsAfterFinished != nil {
 		in, out := &in.TTLSecondsAfterFinished, &out.TTLSecondsAfterFinished
 		*out = new(int32)

--- a/pkg/client/applyconfiguration/batch/v1alpha1/jobspec.go
+++ b/pkg/client/applyconfiguration/batch/v1alpha1/jobspec.go
@@ -33,6 +33,7 @@ type JobSpecApplyConfiguration struct {
 	RunningEstimate         *v1.Duration                           `json:"runningEstimate,omitempty"`
 	Queue                   *string                                `json:"queue,omitempty"`
 	MaxRetry                *int32                                 `json:"maxRetry,omitempty"`
+	ActiveDeadlineSeconds   *int64                                 `json:"activeDeadlineSeconds,omitempty"`
 	TTLSecondsAfterFinished *int32                                 `json:"ttlSecondsAfterFinished,omitempty"`
 	PriorityClassName       *string                                `json:"priorityClassName,omitempty"`
 	MinSuccess              *int32                                 `json:"minSuccess,omitempty"`
@@ -135,6 +136,14 @@ func (b *JobSpecApplyConfiguration) WithQueue(value string) *JobSpecApplyConfigu
 // If called multiple times, the MaxRetry field is set to the value of the last call.
 func (b *JobSpecApplyConfiguration) WithMaxRetry(value int32) *JobSpecApplyConfiguration {
 	b.MaxRetry = &value
+	return b
+}
+
+// WithActiveDeadlineSeconds sets the ActiveDeadlineSeconds field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ActiveDeadlineSeconds field is set to the value of the last call.
+func (b *JobSpecApplyConfiguration) WithActiveDeadlineSeconds(value int64) *JobSpecApplyConfiguration {
+	b.ActiveDeadlineSeconds = &value
 	return b
 }
 

--- a/pkg/client/applyconfiguration/batch/v1alpha1/networktopologyspec.go
+++ b/pkg/client/applyconfiguration/batch/v1alpha1/networktopologyspec.go
@@ -18,14 +18,14 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	batchv1alpha1 "volcano.sh/apis/pkg/apis/batch/v1alpha1"
 )
 
 // NetworkTopologySpecApplyConfiguration represents a declarative configuration of the NetworkTopologySpec type for use
 // with apply.
 type NetworkTopologySpecApplyConfiguration struct {
-	Mode               *v1alpha1.NetworkTopologyMode `json:"mode,omitempty"`
-	HighestTierAllowed *int                          `json:"highestTierAllowed,omitempty"`
+	Mode               *batchv1alpha1.NetworkTopologyMode `json:"mode,omitempty"`
+	HighestTierAllowed *int                               `json:"highestTierAllowed,omitempty"`
 }
 
 // NetworkTopologySpecApplyConfiguration constructs a declarative configuration of the NetworkTopologySpec type for use with
@@ -37,7 +37,7 @@ func NetworkTopologySpec() *NetworkTopologySpecApplyConfiguration {
 // WithMode sets the Mode field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Mode field is set to the value of the last call.
-func (b *NetworkTopologySpecApplyConfiguration) WithMode(value v1alpha1.NetworkTopologyMode) *NetworkTopologySpecApplyConfiguration {
+func (b *NetworkTopologySpecApplyConfiguration) WithMode(value batchv1alpha1.NetworkTopologyMode) *NetworkTopologySpecApplyConfiguration {
 	b.Mode = &value
 	return b
 }

--- a/pkg/client/applyconfiguration/scheduling/v1beta1/networktopologyspec.go
+++ b/pkg/client/applyconfiguration/scheduling/v1beta1/networktopologyspec.go
@@ -18,14 +18,14 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 )
 
 // NetworkTopologySpecApplyConfiguration represents a declarative configuration of the NetworkTopologySpec type for use
 // with apply.
 type NetworkTopologySpecApplyConfiguration struct {
-	Mode               *v1beta1.NetworkTopologyMode `json:"mode,omitempty"`
-	HighestTierAllowed *int                         `json:"highestTierAllowed,omitempty"`
+	Mode               *schedulingv1beta1.NetworkTopologyMode `json:"mode,omitempty"`
+	HighestTierAllowed *int                                   `json:"highestTierAllowed,omitempty"`
 }
 
 // NetworkTopologySpecApplyConfiguration constructs a declarative configuration of the NetworkTopologySpec type for use with
@@ -37,7 +37,7 @@ func NetworkTopologySpec() *NetworkTopologySpecApplyConfiguration {
 // WithMode sets the Mode field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Mode field is set to the value of the last call.
-func (b *NetworkTopologySpecApplyConfiguration) WithMode(value v1beta1.NetworkTopologyMode) *NetworkTopologySpecApplyConfiguration {
+func (b *NetworkTopologySpecApplyConfiguration) WithMode(value schedulingv1beta1.NetworkTopologyMode) *NetworkTopologySpecApplyConfiguration {
 	b.Mode = &value
 	return b
 }

--- a/pkg/client/applyconfiguration/topology/v1alpha1/hypernode.go
+++ b/pkg/client/applyconfiguration/topology/v1alpha1/hypernode.go
@@ -46,7 +46,7 @@ func HyperNode(name string) *HyperNodeApplyConfiguration {
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Kind field is set to the value of the last call.
 func (b *HyperNodeApplyConfiguration) WithKind(value string) *HyperNodeApplyConfiguration {
-	b.Kind = &value
+	b.TypeMetaApplyConfiguration.Kind = &value
 	return b
 }
 
@@ -54,7 +54,7 @@ func (b *HyperNodeApplyConfiguration) WithKind(value string) *HyperNodeApplyConf
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the APIVersion field is set to the value of the last call.
 func (b *HyperNodeApplyConfiguration) WithAPIVersion(value string) *HyperNodeApplyConfiguration {
-	b.APIVersion = &value
+	b.TypeMetaApplyConfiguration.APIVersion = &value
 	return b
 }
 
@@ -63,7 +63,7 @@ func (b *HyperNodeApplyConfiguration) WithAPIVersion(value string) *HyperNodeApp
 // If called multiple times, the Name field is set to the value of the last call.
 func (b *HyperNodeApplyConfiguration) WithName(value string) *HyperNodeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
-	b.Name = &value
+	b.ObjectMetaApplyConfiguration.Name = &value
 	return b
 }
 
@@ -72,7 +72,7 @@ func (b *HyperNodeApplyConfiguration) WithName(value string) *HyperNodeApplyConf
 // If called multiple times, the GenerateName field is set to the value of the last call.
 func (b *HyperNodeApplyConfiguration) WithGenerateName(value string) *HyperNodeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
-	b.GenerateName = &value
+	b.ObjectMetaApplyConfiguration.GenerateName = &value
 	return b
 }
 
@@ -81,7 +81,7 @@ func (b *HyperNodeApplyConfiguration) WithGenerateName(value string) *HyperNodeA
 // If called multiple times, the Namespace field is set to the value of the last call.
 func (b *HyperNodeApplyConfiguration) WithNamespace(value string) *HyperNodeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
-	b.Namespace = &value
+	b.ObjectMetaApplyConfiguration.Namespace = &value
 	return b
 }
 
@@ -90,7 +90,7 @@ func (b *HyperNodeApplyConfiguration) WithNamespace(value string) *HyperNodeAppl
 // If called multiple times, the UID field is set to the value of the last call.
 func (b *HyperNodeApplyConfiguration) WithUID(value types.UID) *HyperNodeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
-	b.UID = &value
+	b.ObjectMetaApplyConfiguration.UID = &value
 	return b
 }
 
@@ -99,7 +99,7 @@ func (b *HyperNodeApplyConfiguration) WithUID(value types.UID) *HyperNodeApplyCo
 // If called multiple times, the ResourceVersion field is set to the value of the last call.
 func (b *HyperNodeApplyConfiguration) WithResourceVersion(value string) *HyperNodeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
-	b.ResourceVersion = &value
+	b.ObjectMetaApplyConfiguration.ResourceVersion = &value
 	return b
 }
 
@@ -108,7 +108,7 @@ func (b *HyperNodeApplyConfiguration) WithResourceVersion(value string) *HyperNo
 // If called multiple times, the Generation field is set to the value of the last call.
 func (b *HyperNodeApplyConfiguration) WithGeneration(value int64) *HyperNodeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
-	b.Generation = &value
+	b.ObjectMetaApplyConfiguration.Generation = &value
 	return b
 }
 
@@ -117,7 +117,7 @@ func (b *HyperNodeApplyConfiguration) WithGeneration(value int64) *HyperNodeAppl
 // If called multiple times, the CreationTimestamp field is set to the value of the last call.
 func (b *HyperNodeApplyConfiguration) WithCreationTimestamp(value metav1.Time) *HyperNodeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
-	b.CreationTimestamp = &value
+	b.ObjectMetaApplyConfiguration.CreationTimestamp = &value
 	return b
 }
 
@@ -126,7 +126,7 @@ func (b *HyperNodeApplyConfiguration) WithCreationTimestamp(value metav1.Time) *
 // If called multiple times, the DeletionTimestamp field is set to the value of the last call.
 func (b *HyperNodeApplyConfiguration) WithDeletionTimestamp(value metav1.Time) *HyperNodeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
-	b.DeletionTimestamp = &value
+	b.ObjectMetaApplyConfiguration.DeletionTimestamp = &value
 	return b
 }
 
@@ -135,7 +135,7 @@ func (b *HyperNodeApplyConfiguration) WithDeletionTimestamp(value metav1.Time) *
 // If called multiple times, the DeletionGracePeriodSeconds field is set to the value of the last call.
 func (b *HyperNodeApplyConfiguration) WithDeletionGracePeriodSeconds(value int64) *HyperNodeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
-	b.DeletionGracePeriodSeconds = &value
+	b.ObjectMetaApplyConfiguration.DeletionGracePeriodSeconds = &value
 	return b
 }
 
@@ -145,11 +145,11 @@ func (b *HyperNodeApplyConfiguration) WithDeletionGracePeriodSeconds(value int64
 // overwriting an existing map entries in Labels field with the same key.
 func (b *HyperNodeApplyConfiguration) WithLabels(entries map[string]string) *HyperNodeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
-	if b.Labels == nil && len(entries) > 0 {
-		b.Labels = make(map[string]string, len(entries))
+	if b.ObjectMetaApplyConfiguration.Labels == nil && len(entries) > 0 {
+		b.ObjectMetaApplyConfiguration.Labels = make(map[string]string, len(entries))
 	}
 	for k, v := range entries {
-		b.Labels[k] = v
+		b.ObjectMetaApplyConfiguration.Labels[k] = v
 	}
 	return b
 }
@@ -160,11 +160,11 @@ func (b *HyperNodeApplyConfiguration) WithLabels(entries map[string]string) *Hyp
 // overwriting an existing map entries in Annotations field with the same key.
 func (b *HyperNodeApplyConfiguration) WithAnnotations(entries map[string]string) *HyperNodeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
-	if b.Annotations == nil && len(entries) > 0 {
-		b.Annotations = make(map[string]string, len(entries))
+	if b.ObjectMetaApplyConfiguration.Annotations == nil && len(entries) > 0 {
+		b.ObjectMetaApplyConfiguration.Annotations = make(map[string]string, len(entries))
 	}
 	for k, v := range entries {
-		b.Annotations[k] = v
+		b.ObjectMetaApplyConfiguration.Annotations[k] = v
 	}
 	return b
 }
@@ -178,7 +178,7 @@ func (b *HyperNodeApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRef
 		if values[i] == nil {
 			panic("nil value passed to WithOwnerReferences")
 		}
-		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+		b.ObjectMetaApplyConfiguration.OwnerReferences = append(b.ObjectMetaApplyConfiguration.OwnerReferences, *values[i])
 	}
 	return b
 }
@@ -189,7 +189,7 @@ func (b *HyperNodeApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRef
 func (b *HyperNodeApplyConfiguration) WithFinalizers(values ...string) *HyperNodeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
-		b.Finalizers = append(b.Finalizers, values[i])
+		b.ObjectMetaApplyConfiguration.Finalizers = append(b.ObjectMetaApplyConfiguration.Finalizers, values[i])
 	}
 	return b
 }
@@ -219,5 +219,5 @@ func (b *HyperNodeApplyConfiguration) WithStatus(value *HyperNodeStatusApplyConf
 // GetName retrieves the value of the Name field in the declarative configuration.
 func (b *HyperNodeApplyConfiguration) GetName() *string {
 	b.ensureObjectMetaApplyConfigurationExists()
-	return b.Name
+	return b.ObjectMetaApplyConfiguration.Name
 }

--- a/pkg/client/applyconfiguration/topology/v1alpha1/memberspec.go
+++ b/pkg/client/applyconfiguration/topology/v1alpha1/memberspec.go
@@ -18,13 +18,13 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
+	topologyv1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
 )
 
 // MemberSpecApplyConfiguration represents a declarative configuration of the MemberSpec type for use
 // with apply.
 type MemberSpecApplyConfiguration struct {
-	Type     *v1alpha1.MemberType              `json:"type,omitempty"`
+	Type     *topologyv1alpha1.MemberType      `json:"type,omitempty"`
 	Selector *MemberSelectorApplyConfiguration `json:"selector,omitempty"`
 }
 
@@ -37,7 +37,7 @@ func MemberSpec() *MemberSpecApplyConfiguration {
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Type field is set to the value of the last call.
-func (b *MemberSpecApplyConfiguration) WithType(value v1alpha1.MemberType) *MemberSpecApplyConfiguration {
+func (b *MemberSpecApplyConfiguration) WithType(value topologyv1alpha1.MemberType) *MemberSpecApplyConfiguration {
 	b.Type = &value
 	return b
 }

--- a/pkg/client/clientset/versioned/typed/topology/v1alpha1/fake/fake_hypernode.go
+++ b/pkg/client/clientset/versioned/typed/topology/v1alpha1/fake/fake_hypernode.go
@@ -18,168 +18,33 @@ limitations under the License.
 package fake
 
 import (
-	"context"
-	json "encoding/json"
-	"fmt"
-
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	testing "k8s.io/client-go/testing"
+	gentype "k8s.io/client-go/gentype"
 	v1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
 	topologyv1alpha1 "volcano.sh/apis/pkg/client/applyconfiguration/topology/v1alpha1"
+	typedtopologyv1alpha1 "volcano.sh/apis/pkg/client/clientset/versioned/typed/topology/v1alpha1"
 )
 
-// FakeHyperNodes implements HyperNodeInterface
-type FakeHyperNodes struct {
+// fakeHyperNodes implements HyperNodeInterface
+type fakeHyperNodes struct {
+	*gentype.FakeClientWithListAndApply[*v1alpha1.HyperNode, *v1alpha1.HyperNodeList, *topologyv1alpha1.HyperNodeApplyConfiguration]
 	Fake *FakeTopologyV1alpha1
 }
 
-var hypernodesResource = v1alpha1.SchemeGroupVersion.WithResource("hypernodes")
-
-var hypernodesKind = v1alpha1.SchemeGroupVersion.WithKind("HyperNode")
-
-// Get takes name of the hyperNode, and returns the corresponding hyperNode object, and an error if there is any.
-func (c *FakeHyperNodes) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.HyperNode, err error) {
-	emptyResult := &v1alpha1.HyperNode{}
-	obj, err := c.Fake.
-		Invokes(testing.NewRootGetActionWithOptions(hypernodesResource, name, options), emptyResult)
-	if obj == nil {
-		return emptyResult, err
+func newFakeHyperNodes(fake *FakeTopologyV1alpha1) typedtopologyv1alpha1.HyperNodeInterface {
+	return &fakeHyperNodes{
+		gentype.NewFakeClientWithListAndApply[*v1alpha1.HyperNode, *v1alpha1.HyperNodeList, *topologyv1alpha1.HyperNodeApplyConfiguration](
+			fake.Fake,
+			"",
+			v1alpha1.SchemeGroupVersion.WithResource("hypernodes"),
+			v1alpha1.SchemeGroupVersion.WithKind("HyperNode"),
+			func() *v1alpha1.HyperNode { return &v1alpha1.HyperNode{} },
+			func() *v1alpha1.HyperNodeList { return &v1alpha1.HyperNodeList{} },
+			func(dst, src *v1alpha1.HyperNodeList) { dst.ListMeta = src.ListMeta },
+			func(list *v1alpha1.HyperNodeList) []*v1alpha1.HyperNode { return gentype.ToPointerSlice(list.Items) },
+			func(list *v1alpha1.HyperNodeList, items []*v1alpha1.HyperNode) {
+				list.Items = gentype.FromPointerSlice(items)
+			},
+		),
+		fake,
 	}
-	return obj.(*v1alpha1.HyperNode), err
-}
-
-// List takes label and field selectors, and returns the list of HyperNodes that match those selectors.
-func (c *FakeHyperNodes) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.HyperNodeList, err error) {
-	emptyResult := &v1alpha1.HyperNodeList{}
-	obj, err := c.Fake.
-		Invokes(testing.NewRootListActionWithOptions(hypernodesResource, hypernodesKind, opts), emptyResult)
-	if obj == nil {
-		return emptyResult, err
-	}
-
-	label, _, _ := testing.ExtractFromListOptions(opts)
-	if label == nil {
-		label = labels.Everything()
-	}
-	list := &v1alpha1.HyperNodeList{ListMeta: obj.(*v1alpha1.HyperNodeList).ListMeta}
-	for _, item := range obj.(*v1alpha1.HyperNodeList).Items {
-		if label.Matches(labels.Set(item.Labels)) {
-			list.Items = append(list.Items, item)
-		}
-	}
-	return list, err
-}
-
-// Watch returns a watch.Interface that watches the requested hyperNodes.
-func (c *FakeHyperNodes) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
-		InvokesWatch(testing.NewRootWatchActionWithOptions(hypernodesResource, opts))
-}
-
-// Create takes the representation of a hyperNode and creates it.  Returns the server's representation of the hyperNode, and an error, if there is any.
-func (c *FakeHyperNodes) Create(ctx context.Context, hyperNode *v1alpha1.HyperNode, opts v1.CreateOptions) (result *v1alpha1.HyperNode, err error) {
-	emptyResult := &v1alpha1.HyperNode{}
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateActionWithOptions(hypernodesResource, hyperNode, opts), emptyResult)
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1alpha1.HyperNode), err
-}
-
-// Update takes the representation of a hyperNode and updates it. Returns the server's representation of the hyperNode, and an error, if there is any.
-func (c *FakeHyperNodes) Update(ctx context.Context, hyperNode *v1alpha1.HyperNode, opts v1.UpdateOptions) (result *v1alpha1.HyperNode, err error) {
-	emptyResult := &v1alpha1.HyperNode{}
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateActionWithOptions(hypernodesResource, hyperNode, opts), emptyResult)
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1alpha1.HyperNode), err
-}
-
-// UpdateStatus was generated because the type contains a Status member.
-// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeHyperNodes) UpdateStatus(ctx context.Context, hyperNode *v1alpha1.HyperNode, opts v1.UpdateOptions) (result *v1alpha1.HyperNode, err error) {
-	emptyResult := &v1alpha1.HyperNode{}
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceActionWithOptions(hypernodesResource, "status", hyperNode, opts), emptyResult)
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1alpha1.HyperNode), err
-}
-
-// Delete takes name of the hyperNode and deletes it. Returns an error if one occurs.
-func (c *FakeHyperNodes) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteActionWithOptions(hypernodesResource, name, opts), &v1alpha1.HyperNode{})
-	return err
-}
-
-// DeleteCollection deletes a collection of objects.
-func (c *FakeHyperNodes) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionActionWithOptions(hypernodesResource, opts, listOpts)
-
-	_, err := c.Fake.Invokes(action, &v1alpha1.HyperNodeList{})
-	return err
-}
-
-// Patch applies the patch and returns the patched hyperNode.
-func (c *FakeHyperNodes) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.HyperNode, err error) {
-	emptyResult := &v1alpha1.HyperNode{}
-	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceActionWithOptions(hypernodesResource, name, pt, data, opts, subresources...), emptyResult)
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1alpha1.HyperNode), err
-}
-
-// Apply takes the given apply declarative configuration, applies it and returns the applied hyperNode.
-func (c *FakeHyperNodes) Apply(ctx context.Context, hyperNode *topologyv1alpha1.HyperNodeApplyConfiguration, opts v1.ApplyOptions) (result *v1alpha1.HyperNode, err error) {
-	if hyperNode == nil {
-		return nil, fmt.Errorf("hyperNode provided to Apply must not be nil")
-	}
-	data, err := json.Marshal(hyperNode)
-	if err != nil {
-		return nil, err
-	}
-	name := hyperNode.Name
-	if name == nil {
-		return nil, fmt.Errorf("hyperNode.Name must be provided to Apply")
-	}
-	emptyResult := &v1alpha1.HyperNode{}
-	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceActionWithOptions(hypernodesResource, *name, types.ApplyPatchType, data, opts.ToPatchOptions()), emptyResult)
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1alpha1.HyperNode), err
-}
-
-// ApplyStatus was generated because the type contains a Status member.
-// Add a +genclient:noStatus comment above the type to avoid generating ApplyStatus().
-func (c *FakeHyperNodes) ApplyStatus(ctx context.Context, hyperNode *topologyv1alpha1.HyperNodeApplyConfiguration, opts v1.ApplyOptions) (result *v1alpha1.HyperNode, err error) {
-	if hyperNode == nil {
-		return nil, fmt.Errorf("hyperNode provided to Apply must not be nil")
-	}
-	data, err := json.Marshal(hyperNode)
-	if err != nil {
-		return nil, err
-	}
-	name := hyperNode.Name
-	if name == nil {
-		return nil, fmt.Errorf("hyperNode.Name must be provided to Apply")
-	}
-	emptyResult := &v1alpha1.HyperNode{}
-	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceActionWithOptions(hypernodesResource, *name, types.ApplyPatchType, data, opts.ToPatchOptions(), "status"), emptyResult)
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1alpha1.HyperNode), err
 }

--- a/pkg/client/clientset/versioned/typed/topology/v1alpha1/fake/fake_topology_client.go
+++ b/pkg/client/clientset/versioned/typed/topology/v1alpha1/fake/fake_topology_client.go
@@ -28,7 +28,7 @@ type FakeTopologyV1alpha1 struct {
 }
 
 func (c *FakeTopologyV1alpha1) HyperNodes() v1alpha1.HyperNodeInterface {
-	return &FakeHyperNodes{c}
+	return newFakeHyperNodes(c)
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/client/clientset/versioned/typed/topology/v1alpha1/hypernode.go
+++ b/pkg/client/clientset/versioned/typed/topology/v1alpha1/hypernode.go
@@ -18,14 +18,14 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	gentype "k8s.io/client-go/gentype"
-	v1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
-	topologyv1alpha1 "volcano.sh/apis/pkg/client/applyconfiguration/topology/v1alpha1"
+	topologyv1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
+	applyconfigurationtopologyv1alpha1 "volcano.sh/apis/pkg/client/applyconfiguration/topology/v1alpha1"
 	scheme "volcano.sh/apis/pkg/client/clientset/versioned/scheme"
 )
 
@@ -37,36 +37,37 @@ type HyperNodesGetter interface {
 
 // HyperNodeInterface has methods to work with HyperNode resources.
 type HyperNodeInterface interface {
-	Create(ctx context.Context, hyperNode *v1alpha1.HyperNode, opts v1.CreateOptions) (*v1alpha1.HyperNode, error)
-	Update(ctx context.Context, hyperNode *v1alpha1.HyperNode, opts v1.UpdateOptions) (*v1alpha1.HyperNode, error)
+	Create(ctx context.Context, hyperNode *topologyv1alpha1.HyperNode, opts v1.CreateOptions) (*topologyv1alpha1.HyperNode, error)
+	Update(ctx context.Context, hyperNode *topologyv1alpha1.HyperNode, opts v1.UpdateOptions) (*topologyv1alpha1.HyperNode, error)
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-	UpdateStatus(ctx context.Context, hyperNode *v1alpha1.HyperNode, opts v1.UpdateOptions) (*v1alpha1.HyperNode, error)
+	UpdateStatus(ctx context.Context, hyperNode *topologyv1alpha1.HyperNode, opts v1.UpdateOptions) (*topologyv1alpha1.HyperNode, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
-	Get(ctx context.Context, name string, opts v1.GetOptions) (*v1alpha1.HyperNode, error)
-	List(ctx context.Context, opts v1.ListOptions) (*v1alpha1.HyperNodeList, error)
+	Get(ctx context.Context, name string, opts v1.GetOptions) (*topologyv1alpha1.HyperNode, error)
+	List(ctx context.Context, opts v1.ListOptions) (*topologyv1alpha1.HyperNodeList, error)
 	Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error)
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.HyperNode, err error)
-	Apply(ctx context.Context, hyperNode *topologyv1alpha1.HyperNodeApplyConfiguration, opts v1.ApplyOptions) (result *v1alpha1.HyperNode, err error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *topologyv1alpha1.HyperNode, err error)
+	Apply(ctx context.Context, hyperNode *applyconfigurationtopologyv1alpha1.HyperNodeApplyConfiguration, opts v1.ApplyOptions) (result *topologyv1alpha1.HyperNode, err error)
 	// Add a +genclient:noStatus comment above the type to avoid generating ApplyStatus().
-	ApplyStatus(ctx context.Context, hyperNode *topologyv1alpha1.HyperNodeApplyConfiguration, opts v1.ApplyOptions) (result *v1alpha1.HyperNode, err error)
+	ApplyStatus(ctx context.Context, hyperNode *applyconfigurationtopologyv1alpha1.HyperNodeApplyConfiguration, opts v1.ApplyOptions) (result *topologyv1alpha1.HyperNode, err error)
 	HyperNodeExpansion
 }
 
 // hyperNodes implements HyperNodeInterface
 type hyperNodes struct {
-	*gentype.ClientWithListAndApply[*v1alpha1.HyperNode, *v1alpha1.HyperNodeList, *topologyv1alpha1.HyperNodeApplyConfiguration]
+	*gentype.ClientWithListAndApply[*topologyv1alpha1.HyperNode, *topologyv1alpha1.HyperNodeList, *applyconfigurationtopologyv1alpha1.HyperNodeApplyConfiguration]
 }
 
 // newHyperNodes returns a HyperNodes
 func newHyperNodes(c *TopologyV1alpha1Client) *hyperNodes {
 	return &hyperNodes{
-		gentype.NewClientWithListAndApply[*v1alpha1.HyperNode, *v1alpha1.HyperNodeList, *topologyv1alpha1.HyperNodeApplyConfiguration](
+		gentype.NewClientWithListAndApply[*topologyv1alpha1.HyperNode, *topologyv1alpha1.HyperNodeList, *applyconfigurationtopologyv1alpha1.HyperNodeApplyConfiguration](
 			"hypernodes",
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			"",
-			func() *v1alpha1.HyperNode { return &v1alpha1.HyperNode{} },
-			func() *v1alpha1.HyperNodeList { return &v1alpha1.HyperNodeList{} }),
+			func() *topologyv1alpha1.HyperNode { return &topologyv1alpha1.HyperNode{} },
+			func() *topologyv1alpha1.HyperNodeList { return &topologyv1alpha1.HyperNodeList{} },
+		),
 	}
 }

--- a/pkg/client/clientset/versioned/typed/topology/v1alpha1/topology_client.go
+++ b/pkg/client/clientset/versioned/typed/topology/v1alpha1/topology_client.go
@@ -18,11 +18,11 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"net/http"
+	http "net/http"
 
 	rest "k8s.io/client-go/rest"
-	v1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
-	"volcano.sh/apis/pkg/client/clientset/versioned/scheme"
+	topologyv1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
+	scheme "volcano.sh/apis/pkg/client/clientset/versioned/scheme"
 )
 
 type TopologyV1alpha1Interface interface {
@@ -84,10 +84,10 @@ func New(c rest.Interface) *TopologyV1alpha1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1alpha1.SchemeGroupVersion
+	gv := topologyv1alpha1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	config.NegotiatedSerializer = rest.CodecFactoryForGeneratedClient(scheme.Scheme, scheme.Codecs).WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/pkg/client/informers/externalversions/topology/v1alpha1/hypernode.go
+++ b/pkg/client/informers/externalversions/topology/v1alpha1/hypernode.go
@@ -18,24 +18,24 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
+	context "context"
 	time "time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
-	topologyv1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
+	apistopologyv1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
 	versioned "volcano.sh/apis/pkg/client/clientset/versioned"
 	internalinterfaces "volcano.sh/apis/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "volcano.sh/apis/pkg/client/listers/topology/v1alpha1"
+	topologyv1alpha1 "volcano.sh/apis/pkg/client/listers/topology/v1alpha1"
 )
 
 // HyperNodeInformer provides access to a shared informer and lister for
 // HyperNodes.
 type HyperNodeInformer interface {
 	Informer() cache.SharedIndexInformer
-	Lister() v1alpha1.HyperNodeLister
+	Lister() topologyv1alpha1.HyperNodeLister
 }
 
 type hyperNodeInformer struct {
@@ -69,7 +69,7 @@ func NewFilteredHyperNodeInformer(client versioned.Interface, resyncPeriod time.
 				return client.TopologyV1alpha1().HyperNodes().Watch(context.TODO(), options)
 			},
 		},
-		&topologyv1alpha1.HyperNode{},
+		&apistopologyv1alpha1.HyperNode{},
 		resyncPeriod,
 		indexers,
 	)
@@ -80,9 +80,9 @@ func (f *hyperNodeInformer) defaultInformer(client versioned.Interface, resyncPe
 }
 
 func (f *hyperNodeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&topologyv1alpha1.HyperNode{}, f.defaultInformer)
+	return f.factory.InformerFor(&apistopologyv1alpha1.HyperNode{}, f.defaultInformer)
 }
 
-func (f *hyperNodeInformer) Lister() v1alpha1.HyperNodeLister {
-	return v1alpha1.NewHyperNodeLister(f.Informer().GetIndexer())
+func (f *hyperNodeInformer) Lister() topologyv1alpha1.HyperNodeLister {
+	return topologyv1alpha1.NewHyperNodeLister(f.Informer().GetIndexer())
 }

--- a/pkg/client/listers/topology/v1alpha1/hypernode.go
+++ b/pkg/client/listers/topology/v1alpha1/hypernode.go
@@ -18,10 +18,10 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/listers"
-	"k8s.io/client-go/tools/cache"
-	v1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
+	labels "k8s.io/apimachinery/pkg/labels"
+	listers "k8s.io/client-go/listers"
+	cache "k8s.io/client-go/tools/cache"
+	topologyv1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
 )
 
 // HyperNodeLister helps list HyperNodes.
@@ -29,19 +29,19 @@ import (
 type HyperNodeLister interface {
 	// List lists all HyperNodes in the indexer.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1alpha1.HyperNode, err error)
+	List(selector labels.Selector) (ret []*topologyv1alpha1.HyperNode, err error)
 	// Get retrieves the HyperNode from the index for a given name.
 	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1alpha1.HyperNode, error)
+	Get(name string) (*topologyv1alpha1.HyperNode, error)
 	HyperNodeListerExpansion
 }
 
 // hyperNodeLister implements the HyperNodeLister interface.
 type hyperNodeLister struct {
-	listers.ResourceIndexer[*v1alpha1.HyperNode]
+	listers.ResourceIndexer[*topologyv1alpha1.HyperNode]
 }
 
 // NewHyperNodeLister returns a new HyperNodeLister.
 func NewHyperNodeLister(indexer cache.Indexer) HyperNodeLister {
-	return &hyperNodeLister{listers.New[*v1alpha1.HyperNode](indexer, v1alpha1.Resource("hypernode"))}
+	return &hyperNodeLister{listers.New[*topologyv1alpha1.HyperNode](indexer, topologyv1alpha1.Resource("hypernode"))}
 }


### PR DESCRIPTION
### What this PR does

- Adds the `ActiveDeadlineSeconds` field to the Volcano JobSpec.
- This allows users to specify a maximum duration for jobs, after which they are automatically terminated.

### Why is this needed?

This is required for the feature request in volcano-sh/volcano#2761.

---

Required for volcano-sh/volcano#2761