### PR TITLE
Add default comment and defaulting logic for TaskSpec.MinAvailable

### DIFF
--- a/pkg/apis/batch/v1alpha1/job.go
+++ b/pkg/apis/batch/v1alpha1/job.go
@@ -252,6 +252,13 @@ type TaskSpec struct {
 	DependsOn *DependsOn `json:"dependsOn,omitempty" protobuf:"bytes,8,opt,name=dependsOn"`
 }
 
+// Default sets default values for TaskSpec fields.
+func (t *TaskSpec) Default() {
+	if t.MinAvailable == nil {
+		t.MinAvailable = &t.Replicas
+	}
+}
+
 // JobPhase defines the phase of the job.
 type JobPhase string
 


### PR DESCRIPTION
This PR adds a comment to TaskSpec.MinAvailable indicating it defaults to the task's Replicas, and implements a Default() method to set MinAvailable to Replicas if unset.