### PR TITLE
implemented the Preemptable field for podgroup api

### DIFF
--- a/pkg/apis/scheduling/types.go
+++ b/pkg/apis/scheduling/types.go
@@ -196,6 +196,12 @@ type PodGroupSpec struct {
 	// NetworkTopology defines the NetworkTopology config, this field works in conjunction with network topology feature and hyperNode CRD.
 	// +optional
 	NetworkTopology *NetworkTopologySpec
+
+	// Preemptable indicates whether the PodGroup can be preempted by other PodGroups.
+	// When nil or true, the PodGroup can be preempted for compatibility.
+	// When false, the PodGroup cannot be preempted.
+	// +optional
+	Preemptable *bool
 }
 
 // NetworkTopologyMode represents the networkTopology mode, valid values are "hard" and "soft".

--- a/pkg/apis/scheduling/v1beta1/types.go
+++ b/pkg/apis/scheduling/v1beta1/types.go
@@ -204,6 +204,12 @@ type PodGroupSpec struct {
 	// NetworkTopology defines the NetworkTopology config, this field works in conjunction with network topology feature and hyperNode CRD.
 	// +optional
 	NetworkTopology *NetworkTopologySpec `json:"networkTopology,omitempty" protobuf:"bytes,5,opt,name=networkTopology"`
+
+	// Preemptable indicates whether the PodGroup can be preempted by other PodGroups.
+	// When nil or true, the PodGroup can be preempted for compatibility.
+	// When false, the PodGroup cannot be preempted.
+	// +optional
+	Preemptable *bool `json:"preemptable,omitempty" protobuf:"bytes,6,opt,name=preemptable"`
 }
 
 type NetworkTopologyMode string

--- a/pkg/apis/scheduling/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/scheduling/v1beta1/zz_generated.conversion.go
@@ -422,6 +422,7 @@ func autoConvert_v1beta1_PodGroupSpec_To_scheduling_PodGroupSpec(in *PodGroupSpe
 	out.PriorityClassName = in.PriorityClassName
 	out.MinResources = (*v1.ResourceList)(unsafe.Pointer(in.MinResources))
 	out.NetworkTopology = (*scheduling.NetworkTopologySpec)(unsafe.Pointer(in.NetworkTopology))
+	out.Preemptable = (*bool)(unsafe.Pointer(in.Preemptable))
 	return nil
 }
 
@@ -437,6 +438,7 @@ func autoConvert_scheduling_PodGroupSpec_To_v1beta1_PodGroupSpec(in *scheduling.
 	out.PriorityClassName = in.PriorityClassName
 	out.MinResources = (*v1.ResourceList)(unsafe.Pointer(in.MinResources))
 	out.NetworkTopology = (*NetworkTopologySpec)(unsafe.Pointer(in.NetworkTopology))
+	out.Preemptable = (*bool)(unsafe.Pointer(in.Preemptable))
 	return nil
 }
 

--- a/pkg/apis/scheduling/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/scheduling/v1beta1/zz_generated.deepcopy.go
@@ -275,6 +275,11 @@ func (in *PodGroupSpec) DeepCopyInto(out *PodGroupSpec) {
 		*out = new(NetworkTopologySpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Preemptable != nil {
+		in, out := &in.Preemptable, &out.Preemptable
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/scheduling/zz_generated.deepcopy.go
+++ b/pkg/apis/scheduling/zz_generated.deepcopy.go
@@ -275,6 +275,11 @@ func (in *PodGroupSpec) DeepCopyInto(out *PodGroupSpec) {
 		*out = new(NetworkTopologySpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Preemptable != nil {
+		in, out := &in.Preemptable, &out.Preemptable
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/client/applyconfiguration/scheduling/v1beta1/podgroupspec.go
+++ b/pkg/client/applyconfiguration/scheduling/v1beta1/podgroupspec.go
@@ -30,6 +30,7 @@ type PodGroupSpecApplyConfiguration struct {
 	PriorityClassName *string                                `json:"priorityClassName,omitempty"`
 	MinResources      *v1.ResourceList                       `json:"minResources,omitempty"`
 	NetworkTopology   *NetworkTopologySpecApplyConfiguration `json:"networkTopology,omitempty"`
+	Preemptable       *bool                                  `json:"preemptable,omitempty"`
 }
 
 // PodGroupSpecApplyConfiguration constructs a declarative configuration of the PodGroupSpec type for use with
@@ -89,5 +90,13 @@ func (b *PodGroupSpecApplyConfiguration) WithMinResources(value v1.ResourceList)
 // If called multiple times, the NetworkTopology field is set to the value of the last call.
 func (b *PodGroupSpecApplyConfiguration) WithNetworkTopology(value *NetworkTopologySpecApplyConfiguration) *PodGroupSpecApplyConfiguration {
 	b.NetworkTopology = value
+	return b
+}
+
+// WithPreemptable sets the Preemptable field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Preemptable field is set to the value of the last call.
+func (b *PodGroupSpecApplyConfiguration) WithPreemptable(value bool) *PodGroupSpecApplyConfiguration {
+	b.Preemptable = &value
 	return b
 }


### PR DESCRIPTION
## Problem
Current preemptable behavior uses annotations/labels with default `false`, limiting compatibility.

## Solution
Add native `Preemptable *bool` field to `PodGroupSpec`:
- `nil` or `true` → can be preempted (for compatibility)
- `false` → cannot be preempted

## Changes
- Added field to both API repos (`apis/`, `volcano-apis/`)
- Updated scheduler logic to check field first, fall back to annotations
- Regenerated client code