### PR TITLE
feat: add DequeueStrategy field to QueueSpec for configurable queue dequeue behavior

### DIFF
--- a/pkg/apis/scheduling/types.go
+++ b/pkg/apis/scheduling/types.go
@@ -386,7 +386,25 @@ type QueueSpec struct {
 	// Priority define the priority of queue. Higher values are prioritized for scheduling and considered later during reclamation.
 	// +optional
 	Priority int32 `json:"priority,omitempty" protobuf:"bytes,10,opt,name=priority"`
+
+	// DequeueStrategy defines the dequeue strategy of queue
+	// +optional
+	DequeueStrategy DequeueStrategy `json:"dequeueStrategy,omitempty" protobuf:"bytes,11,opt,name=dequeueStrategy"`
 }
+
+type DequeueStrategy string
+
+const (
+	// DequeueStrategyFIFO defines a strict FIFO strategy. If the head of the queue cannot be scheduled,
+	// the system will not attempt to dequeue other jobs from the queue.
+	DequeueStrategyFIFO DequeueStrategy = "fifo"
+	// DequeueStrategyTraverse defines a strategy that traverses the queue. If the head of the queue cannot be scheduled,
+	// it will be skipped and the scheduler will attempt to dequeue subsequent jobs.
+	DequeueStrategyTraverse DequeueStrategy = "traverse"
+
+	// DefaultDequeueStrategy is the default dequeue strategy.
+	DefaultDequeueStrategy DequeueStrategy = DequeueStrategyTraverse
+)
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/pkg/apis/scheduling/v1beta1/types.go
+++ b/pkg/apis/scheduling/v1beta1/types.go
@@ -410,7 +410,27 @@ type QueueSpec struct {
 	// Priority define the priority of queue. Higher values are prioritized for scheduling and considered later during reclamation.
 	// +optional
 	Priority int32 `json:"priority,omitempty" protobuf:"bytes,10,opt,name=priority"`
+
+	// DequeueStrategy defines the dequeue strategy of queue
+	// +optional
+	// +kubebuilder:default:=traverse
+	// +kubebuilder:validation:Enum=fifo;traverse
+	DequeueStrategy DequeueStrategy `json:"dequeueStrategy,omitempty" protobuf:"bytes,11,opt,name=dequeueStrategy"`
 }
+
+type DequeueStrategy string
+
+const (
+	// DequeueStrategyFIFO defines a strict FIFO strategy. If the head of the queue cannot be scheduled,
+	// the system will not attempt to dequeue other jobs from the queue.
+	DequeueStrategyFIFO DequeueStrategy = "fifo"
+	// DequeueStrategyTraverse defines a strategy that traverses the queue. If the head of the queue cannot be scheduled,
+	// it will be skipped and the scheduler will attempt to dequeue subsequent jobs.
+	DequeueStrategyTraverse DequeueStrategy = "traverse"
+
+	// DefaultDequeueStrategy is the default dequeue strategy.
+	DefaultDequeueStrategy DequeueStrategy = DequeueStrategyTraverse
+)
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true

--- a/pkg/apis/scheduling/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/scheduling/v1beta1/zz_generated.conversion.go
@@ -540,6 +540,7 @@ func autoConvert_v1beta1_QueueSpec_To_scheduling_QueueSpec(in *QueueSpec, out *s
 	out.Parent = in.Parent
 	out.Deserved = *(*v1.ResourceList)(unsafe.Pointer(&in.Deserved))
 	out.Priority = in.Priority
+	out.DequeueStrategy = scheduling.DequeueStrategy(in.DequeueStrategy)
 	return nil
 }
 
@@ -561,6 +562,7 @@ func autoConvert_scheduling_QueueSpec_To_v1beta1_QueueSpec(in *scheduling.QueueS
 	out.Parent = in.Parent
 	out.Deserved = *(*v1.ResourceList)(unsafe.Pointer(&in.Deserved))
 	out.Priority = in.Priority
+	out.DequeueStrategy = DequeueStrategy(in.DequeueStrategy)
 	return nil
 }
 

--- a/pkg/client/applyconfiguration/scheduling/v1beta1/queuespec.go
+++ b/pkg/client/applyconfiguration/scheduling/v1beta1/queuespec.go
@@ -19,21 +19,23 @@ package v1beta1
 
 import (
 	v1 "k8s.io/api/core/v1"
+	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 )
 
 // QueueSpecApplyConfiguration represents a declarative configuration of the QueueSpec type for use
 // with apply.
 type QueueSpecApplyConfiguration struct {
-	Weight         *int32                       `json:"weight,omitempty"`
-	Capability     *v1.ResourceList             `json:"capability,omitempty"`
-	Reclaimable    *bool                        `json:"reclaimable,omitempty"`
-	ExtendClusters []ClusterApplyConfiguration  `json:"extendClusters,omitempty"`
-	Guarantee      *GuaranteeApplyConfiguration `json:"guarantee,omitempty"`
-	Affinity       *AffinityApplyConfiguration  `json:"affinity,omitempty"`
-	Type           *string                      `json:"type,omitempty"`
-	Parent         *string                      `json:"parent,omitempty"`
-	Deserved       *v1.ResourceList             `json:"deserved,omitempty"`
-	Priority       *int32                       `json:"priority,omitempty"`
+	Weight          *int32                             `json:"weight,omitempty"`
+	Capability      *v1.ResourceList                   `json:"capability,omitempty"`
+	Reclaimable     *bool                              `json:"reclaimable,omitempty"`
+	ExtendClusters  []ClusterApplyConfiguration        `json:"extendClusters,omitempty"`
+	Guarantee       *GuaranteeApplyConfiguration       `json:"guarantee,omitempty"`
+	Affinity        *AffinityApplyConfiguration        `json:"affinity,omitempty"`
+	Type            *string                            `json:"type,omitempty"`
+	Parent          *string                            `json:"parent,omitempty"`
+	Deserved        *v1.ResourceList                   `json:"deserved,omitempty"`
+	Priority        *int32                             `json:"priority,omitempty"`
+	DequeueStrategy *schedulingv1beta1.DequeueStrategy `json:"dequeueStrategy,omitempty"`
 }
 
 // QueueSpecApplyConfiguration constructs a declarative configuration of the QueueSpec type for use with
@@ -124,5 +126,13 @@ func (b *QueueSpecApplyConfiguration) WithDeserved(value v1.ResourceList) *Queue
 // If called multiple times, the Priority field is set to the value of the last call.
 func (b *QueueSpecApplyConfiguration) WithPriority(value int32) *QueueSpecApplyConfiguration {
 	b.Priority = &value
+	return b
+}
+
+// WithDequeueStrategy sets the DequeueStrategy field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the DequeueStrategy field is set to the value of the last call.
+func (b *QueueSpecApplyConfiguration) WithDequeueStrategy(value schedulingv1beta1.DequeueStrategy) *QueueSpecApplyConfiguration {
+	b.DequeueStrategy = &value
 	return b
 }


### PR DESCRIPTION
## Summary

This PR introduces a new `DequeueStrategy` field to the `QueueSpec` API, allowing users to configure how jobs are dequeued from a queue. This provides flexibility in choosing between FIFO (First-In-First-Out) and traverse-based dequeue strategies, with options to sort jobs by creation time or priority.

## Changes

- Added `DequeueStrategy` field to `QueueSpec` in both internal (`pkg/apis/scheduling/types.go`) and v1beta1 (`pkg/apis/scheduling/v1beta1/types.go`) API versions
- Defined `DequeueStrategy` type with four supported strategies:
  - `fifo`: Jobs sorted by `ssn.JobOrderFn`; if the first job cannot be dequeued, retry without skipping
  - `traverse`: Jobs sorted by `ssn.JobOrderFn`; if the first job cannot be dequeued, skip it and try subsequent jobs (default)
- Added kubebuilder validation annotations to restrict values to the four supported strategies
- Set default value to `priority-based-traverse`
- Updated generated code for conversion and client apply configurations
## API Changes

### QueueSpec (Internal API)
```go
// DequeueStrategy define the dequeue strategy of queue
// +optional
DequeueStrategy DequeueStrategy `json:"dequeueStrategy,omitempty" protobuf:"bytes,11,opt,name=dequeueStrategy"`
```

### QueueSpec (v1beta1 API)
```go
// DequeueStrategy define the dequeue strategy of queue
// +optional
// +kubebuilder:default:=traverse
// +kubebuilder:validation:Enum=fifo;traverse
DequeueStrategy DequeueStrategy `json:"dequeueStrategy,omitempty" protobuf:"bytes,11,opt,name=dequeueStrategy"`
```

## Backward Compatibility

This change is backward compatible as:
- The `DequeueStrategy` field is optional
- Default values are provided for both API versions:
  - Internal API defaults to `traverse`
  - v1beta1 API defaults to `traverse`
- Existing queues without this field will use the default strategy


## Related Issues
https://github.com/volcano-sh/volcano/issues/4572

<!-- Add related issue numbers if applicable -->

## Related PR
https://github.com/volcano-sh/volcano/pull/4580

