### PR TITLE
Revert PR #208 - fix xvalidation

### DIFF
--- a/pkg/apis/batch/v1alpha1/job.go
+++ b/pkg/apis/batch/v1alpha1/job.go
@@ -251,7 +251,6 @@ type TaskSpec struct {
 	// The minimal available pods to run for this Task
 	// Defaults to the task replicas
 	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:XValidation:rule="!has(self.minAvailable) || self.minAvailable <= self.replicas",message="minAvailable must not be greater than replicas"
 	// +optional
 	MinAvailable *int32 `json:"minAvailable,omitempty" protobuf:"bytes,3,opt,name=minAvailable"`
 
@@ -279,7 +278,6 @@ type TaskSpec struct {
 	DependsOn *DependsOn `json:"dependsOn,omitempty" protobuf:"bytes,8,opt,name=dependsOn"`
 
 	// PartitionPolicy defines the partition policy of a task.
-	// +kubebuilder:validation:XValidation:rule="!has(self.partitionPolicy) || self.partitionPolicy.totalPartitions * self.partitionPolicy.partitionSize == self.replicas",message="The product of totalPartitions and partitionSize must equal replicas"
 	// +optional
 	PartitionPolicy *PartitionPolicySpec `json:"partitionPolicy,omitempty" protobuf:"bytes,9,opt,name=partitionPolicy"`
 }


### PR DESCRIPTION
@hzxuzhonghu 
Revert PR #208

I ignored the cost issue.The x-kubernetes-validations should be removed because the CEL validation expressions exceeded Kubernetes' 15% cost budget limit for CRD schema validation, which would cause the API server to reject the CRD definitions.These verifications will be retained in wehook.

https://github.com/volcano-sh/volcano/issues/4806