### PR TITLE
feat: add selectabledfield for queue and podgroup

### DIFF
--- a/pkg/apis/scheduling/v1beta1/types.go
+++ b/pkg/apis/scheduling/v1beta1/types.go
@@ -150,6 +150,7 @@ const (
 // +kubebuilder:printcolumn:name="RUNNINGS",type=integer,JSONPath=`.status.running`
 // +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:printcolumn:name="QUEUE",type=string,priority=1,JSONPath=`.spec.queue`
+// +kubebuilder:selectablefield:JSONPath=`.spec.queue`
 
 // PodGroup is a collection of Pod; used for batch workload.
 type PodGroup struct {
@@ -349,6 +350,7 @@ const (
 // +kubebuilder:resource:path=queues,scope=Cluster,shortName=q;queue-v1beta1
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="PARENT",type=string,JSONPath=`.spec.parent`
+// +kubebuilder:selectablefield:JSONPath=`.spec.parent`
 
 // Queue is a queue of PodGroup.
 type Queue struct {


### PR DESCRIPTION
- Add selectabledfield `parent` for  Queue, so user can list queues with specific parent queue.
- Add selectabledfiled `queue` for PodGroup, so user can list podgroups with specific queue.